### PR TITLE
Add 0x4248 (VAR_IN_TEMP_WATER_LAW_TARGET_F) and 0x40c4 (ENUM_IN_WATERPUMP_PWM_VALUE)

### DIFF
--- a/components/samsung_nasa/nasa/numbers.py
+++ b/components/samsung_nasa/nasa/numbers.py
@@ -107,6 +107,13 @@ numbers = {
         CONF_DATA: cmd_numeric_data(15, 55),
         CONF_DEFAULTS: temperature_defaults()
     },
+    0x4248: {
+        NASA_LABEL: "VAR_IN_TEMP_WATER_LAW_TARGET_F",
+        NASA_MODE: CONTROLLER_MODE_CONTROL,
+        CONF_DATA: cmd_numeric_data(-5, +5,0.5),
+        CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_CONFIG,
+        CONF_DEFAULTS: temperature_defaults()
+    },
     0x424A: {
         NASA_LABEL: "VAR_IN_FSV_1011",
         NASA_MODE: CONTROLLER_MODE_FSV,

--- a/components/samsung_nasa/nasa/sensors.py
+++ b/components/samsung_nasa/nasa/sensors.py
@@ -120,6 +120,16 @@ sensors = {
         NASA_MODE: CONTROLLER_MODE_STATUS,
         CONF_DEFAULTS: sensor_defaults()
     },
+    0x40c4: {
+        NASA_LABEL: "ENUM_IN_WATERPUMP_PWM_VALUE",
+        NASA_MODE: CONTROLLER_MODE_STATUS,
+        CONF_DEFAULTS: sensor_defaults(
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_FLOW,
+            device_class=DEVICE_CLASS_EMPTY,
+            state_class=STATE_CLASS_MEASUREMENT
+        )
+    },
     0x4236: {
         NASA_LABEL: "VAR_IN_TEMP_WATER_IN_F ",
         NASA_MODE: CONTROLLER_MODE_STATUS,


### PR DESCRIPTION
Ideally VAR_IN_TEMP_WATER_LAW_TARGET_F (which is the Water Law Offset) would be in the configuration section, but it was beyond my cut and paste ability to do this1