### PR TITLE
Enable Climate Modes in the Samsung NASA Framework Climate Component

### DIFF
--- a/components/samsung_nasa/climate/__init__.py
+++ b/components/samsung_nasa/climate/__init__.py
@@ -41,6 +41,8 @@ CLIMATE_ACTION_SENSOR = "action_mode_sensor"
 CLIMATE_CUSTOM_PRESET_SELECT_ID = "custom_preset_select_id"
 CLIMATE_ACTION_MAPPINGS_ID = "mappings_id"
 CLIMATE_ACTION_MAPPINGS = "mappings"
+CLIMATE_MODE_SELECT_ID = "mode_select_id"
+CLIMATE_SUPPORTED_MODES = "supported_modes"
 ICON_THERMOSTAT = "mdi:thermostat"
 
 def to_pair_schema(config):
@@ -74,10 +76,12 @@ CONFIG_SCHEMA = cv.Schema(
         {  
             cv.Optional(CONF_ICON, default=ICON_THERMOSTAT): cv.icon,
             cv.Optional(CLIMATE_POWER_SWITCH_ID): cv.use_id(switch.Switch),
+            cv.Optional(CLIMATE_MODE_SELECT_ID): cv.use_id(select.Select),
             cv.Optional(CLIMATE_CURRENT_TEMP_ID): cv.use_id(sensor.Sensor),
             cv.Optional(CLIMATE_TARGET_TEMP_ID): cv.use_id(number.Number),
             cv.Optional(CLIMATE_ACTION_SENSOR): CLIMATE_ACTION_MAPPING_SCHEMA,
-            cv.Optional(CLIMATE_CUSTOM_PRESET_SELECT_ID): cv.use_id(select.Select)
+            cv.Optional(CLIMATE_CUSTOM_PRESET_SELECT_ID): cv.use_id(select.Select),
+            cv.Optional(CLIMATE_SUPPORTED_MODES): cv.ensure_list(climate.validate_climate_mode),
         }
     )
 )
@@ -106,6 +110,11 @@ async def to_code(config):
     if CLIMATE_POWER_SWITCH_ID in config:
         power = await cg.get_variable(config[CLIMATE_POWER_SWITCH_ID])
         cg.add(var.set_power_switch(power))
+    if CLIMATE_MODE_SELECT_ID in config:
+        mode_sel = await cg.get_variable(config[CLIMATE_MODE_SELECT_ID])
+        cg.add(var.set_mode_select(mode_sel))
+    if CLIMATE_SUPPORTED_MODES in config:
+        cg.add(var.set_supported_modes(config[CLIMATE_SUPPORTED_MODES]))
     if CLIMATE_CURRENT_TEMP_ID in config:
         current = await cg.get_variable(config[CLIMATE_CURRENT_TEMP_ID])
         cg.add(var.set_current_temp(current))
@@ -125,7 +134,3 @@ async def to_code(config):
                     for key, value in cam.items():                       
                         cg.add(var_map.add_map_entry(key, value))
                     cg.add(var.set_action_map(var_map))
-
-
-    
-

--- a/components/samsung_nasa/climate/nasa_climate.cpp
+++ b/components/samsung_nasa/climate/nasa_climate.cpp
@@ -21,18 +21,59 @@ void NASA_Climate::setup() {
     this->action_sens_->add_on_state_callback([this](float state) { this->on_action_sens(state); });
   }
   if (this->select_presets_ != nullptr) {
-    this->select_presets_->add_on_state_callback(
-        [this](size_t index) { 
-            auto state = this->select_presets_->traits.get_options()[index];
-            this->on_preset_select(state, index); 
-        });
+    this->select_presets_->add_on_state_callback([this](size_t index) {
+      auto state = this->select_presets_->traits.get_options()[index];
+      this->on_preset_select(state, index);
+    });
+  }
+  if (this->mode_select_ != nullptr) {
+    this->mode_select_->add_on_state_callback([this](size_t index) {
+      auto value = this->mode_select_->traits.get_options()[index];
+      climate::ClimateMode new_mode;
+      if (value == "Heat")
+        new_mode = climate::CLIMATE_MODE_HEAT;
+      else if (value == "Cool")
+        new_mode = climate::CLIMATE_MODE_COOL;
+      else if (value == "Dry")
+        new_mode = climate::CLIMATE_MODE_DRY;
+      else if (value == "Fan")
+        new_mode = climate::CLIMATE_MODE_FAN_ONLY;
+      else if (value == "Auto")
+        new_mode = climate::CLIMATE_MODE_HEAT_COOL;
+      else
+        return;  // Unknown mode
+
+      if (this->mode == climate::CLIMATE_MODE_OFF) {
+        // If the unit is OFF, just remember this mode for next time it turns ON
+        this->last_active_mode_ = new_mode;
+      } else {
+        // If the unit is ON, update the actual state
+        this->on_mode_select(new_mode);
+      }
+    });
   }
 }
 
 void NASA_Climate::on_power(bool state) {
-  auto new_mode = state ? climate::ClimateMode::CLIMATE_MODE_HEAT : climate::ClimateMode::CLIMATE_MODE_OFF;
-  if (this->update_mode(new_mode))
-    this->publish_state();
+  if (state) {
+    // 1. Power turned ON. 
+    // If the UI currently says OFF, restore the last known working mode.
+    if (this->mode == climate::CLIMATE_MODE_OFF) {
+      if (this->update_mode(this->last_active_mode_)) {
+        this->publish_state();
+      }
+    }
+  } else {
+    // 2. Power turned OFF.
+    // First, save what we were doing (Heat, Cool, etc.) BEFORE we switch to OFF.
+    if (this->mode != climate::CLIMATE_MODE_OFF) {
+      this->last_active_mode_ = this->mode;
+    }    
+    // Update UI to OFF
+    if (this->update_mode(climate::CLIMATE_MODE_OFF)) {
+      this->publish_state();
+    }
+  }
 }
 
 void NASA_Climate::on_target_temp(float state) {
@@ -50,6 +91,17 @@ void NASA_Climate::on_preset_select(std::string state, size_t index) {
     this->publish_state();
 }
 
+void NASA_Climate::on_mode_select(climate::ClimateMode mode) {
+    // If we update the mode, we should also update the memory 
+    // so the next power toggle stays on this mode.
+    if (mode != climate::CLIMATE_MODE_OFF) {
+        this->last_active_mode_ = mode;
+    }
+    if (this->update_mode(mode)) {
+        this->publish_state();
+    }
+}
+
 void NASA_Climate::on_action_sens(float state) {
   if (this->mappings_ == nullptr)
     return;
@@ -65,12 +117,29 @@ void NASA_Climate::on_action_sens(float state) {
 void NASA_Climate::control(const climate::ClimateCall &call) {
   auto update = false;
   if (call.get_mode().has_value()) {
-    auto updated = this->update_mode(*call.get_mode());
+    climate::ClimateMode new_mode = *call.get_mode();
+    auto updated = this->update_mode(new_mode);
     if (this->power_ != nullptr && updated) {
       if (this->mode == climate::ClimateMode::CLIMATE_MODE_OFF) {
         this->power_->turn_off();
-      } else if (this->mode == climate::ClimateMode::CLIMATE_MODE_HEAT) {
+      } else {
         this->power_->turn_on();
+
+        if (this->mode_select_ != nullptr) {
+          auto call_sel = this->mode_select_->make_call();
+          // Map ClimateMode to Select options strings
+          if (new_mode == climate::CLIMATE_MODE_HEAT)
+            call_sel.set_option("Heat");
+          else if (new_mode == climate::CLIMATE_MODE_COOL)
+            call_sel.set_option("Cool");
+          else if (new_mode == climate::CLIMATE_MODE_DRY)
+            call_sel.set_option("Dry");
+          else if (new_mode == climate::CLIMATE_MODE_FAN_ONLY)
+            call_sel.set_option("Fan");
+          else if (new_mode == climate::CLIMATE_MODE_HEAT_COOL)
+            call_sel.set_option("Auto");
+          call_sel.perform();
+        }
       }
       update = true;
     }
@@ -130,19 +199,27 @@ bool NASA_Climate::update_target_temp(float new_temp) {
   return false;
 }
 
-bool NASA_Climate::update_custom_preset(const char *new_value) {
-    return this->set_custom_preset_(new_value);
-}
+bool NASA_Climate::update_custom_preset(const char *new_value) { return this->set_custom_preset_(new_value); }
 
 climate::ClimateTraits NASA_Climate::traits() {
   climate::ClimateTraits traits{};
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+
+  if (this->supported_modes_.empty()) {
+    // Default fallback
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+  } else {
+    traits.add_supported_mode(climate::CLIMATE_MODE_OFF);
+    for (auto mode : this->supported_modes_) {
+      traits.add_supported_mode(mode);
+    }
+  }
+
   traits.set_supported_presets({});
   if (this->select_presets_ != nullptr) {
     const auto &options = this->select_presets_->traits.get_options();
-    std::vector<const char*> preset_pointers(options.begin(), options.end());
+    std::vector<const char *> preset_pointers(options.begin(), options.end());
     traits.set_supported_custom_presets(preset_pointers);
   }
   return traits;

--- a/components/samsung_nasa/climate/nasa_climate.h
+++ b/components/samsung_nasa/climate/nasa_climate.h
@@ -7,6 +7,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 #include <map>
+#include <set>
 
 namespace esphome {
 namespace samsung_nasa {
@@ -34,6 +35,10 @@ class NASA_Climate : public climate::Climate, public Component {
   void set_action_sensor(sensor::Sensor *action_sens) { this->action_sens_ = action_sens; }
   void set_action_map(ClimateActionMap *mappings) { this->mappings_ = mappings; }
   void set_custom_preset_select(select::Select *custom_presets) { this->select_presets_ = custom_presets; }
+  void set_mode_select(select::Select *mode_select) { this->mode_select_ = mode_select; }
+  void set_supported_modes(std::vector<climate::ClimateMode> modes) { 
+    this->supported_modes_ = {modes.begin(), modes.end()}; 
+  }
   bool update_action(climate::ClimateAction new_action);
 
  protected:
@@ -43,6 +48,7 @@ class NASA_Climate : public climate::Climate, public Component {
   void on_current_temp(float state);
   void on_action_sens(float state);
   void on_preset_select(std::string state, size_t index);
+  void on_mode_select(climate::ClimateMode mode);
   bool update_mode(climate::ClimateMode new_mode);
   bool update_current_temp(float new_temp);
   bool update_target_temp(float new_temp);
@@ -54,7 +60,10 @@ class NASA_Climate : public climate::Climate, public Component {
   sensor::Sensor *current_temp_{nullptr};
   sensor::Sensor *action_sens_{nullptr};
   select::Select *select_presets_{nullptr};
+  select::Select *mode_select_{nullptr};
+  std::set<climate::ClimateMode> supported_modes_{};
   ClimateActionMap *mappings_{nullptr};
+  climate::ClimateMode last_active_mode_{climate::CLIMATE_MODE_HEAT};
 };
 
 }  // namespace samsung_nasa


### PR DESCRIPTION
This update introduces flexible operation (cllimate) mode filtering and "smart memory" for power toggling. Whether you are using a simple on/off zone or a Heat Pump with Cooling capabilities, the component now adapts to your hardware.

✨ Key Features
- Mode Filtering: You can now choose exactly which modes appear in the Home Assistant UI using the supported_modes option.

- Mode Memory: If you turn the unit off, the component remembers if you were in Heat, Cool, or Dry mode. When you turn it back on, it restores that specific mode instead of defaulting to Heat.

- External Sync: Changes made via physical Samsung remotes or other NASA registers (0x4001) will now reflect accurately in the Home Assistant Climate card.

- Backwards Compatible: Existing configurations will continue to work as "Heat/Off" only by default.

Advanced users now have the ability to specify climate modes. This is done by specifying two additional fields. Firstly, you can explicitly link the climate component to the 0x4001 select component (operation/climate mode). The options available with 0x4001 are: "Heat", "Cool", "Auto", "Dry" and "Fan". Secondly, not all of these modes may be required so you can use the supported_modes field to show only the modes your specific indoor unit or zone uses (i.e., hiding the "Cool" mode).

```yaml
climate:
  - platform: samsung_nasa
    name: "Zone 1"
    # The power switch (Register 0x4000)
    power_switch_id: nasa_power_switch     
    # NEW: The mode select (Register 0x4001)
    # Linking this allows ESPHome to force the mode when turning on
    mode_select_id: nasa_mode_select    
    # NEW: UI Filtering
    # Only these options will appear in Home Assistant
    supported_modes:                   
      - HEAT
      - COOL
```
Available options for supported_modes:

| YAML Value  | ESPHome Enum Constant    | NASA Register (0x4001) Mapping      |
| :---        | :---                     | :---                                |
| `OFF`       | `CLIMATE_MODE_OFF`       | Handled via Power Register (0x4000) |
| `HEAT`      | `CLIMATE_MODE_HEAT`      | Maps to the string `"Heat"`         |
| `COOL`      | `CLIMATE_MODE_COOL`      | Maps to the string `"Cool"`         |
| `HEAT_COOL` | `CLIMATE_MODE_HEAT_COOL` | Maps to the string `"Auto"`         |
| `DRY`       | `CLIMATE_MODE_DRY`       | Maps to the string `"Dry"`          |
| `FAN_ONLY`  | `CLIMATE_MODE_FAN_ONLY`  | Maps to the string `"Fan"`          |

### Logic Flow

In this scenario the climate component now manages the relationship between the Power Switch and the Mode Select register to ensure they never get out of sync.

1. Commanding: When you select "Cool" in Home Assistant, the component first ensures the NASA Power register is ON, then sends the "Cool" command to the NASA Mode register.

2. Memory: If the unit is turned off via the NASA framework, the ESPHome component "bookmarks" the current mode.

3. Restore: On a "Power On" command, it re-issues the bookmarked mode to the 0x4001 register, ensuring the unit doesn't default to an unwanted state (like Fan Only).