### PR TITLE
Fixed Warnings for 2026.4.0

### DIFF
--- a/components/samsung_nasa/__init__.py
+++ b/components/samsung_nasa/__init__.py
@@ -123,7 +123,8 @@ nasa_item_base_schema = cv.Schema(
     cv.Schema({
         cv.GenerateID(NASA_CONTROLLER_ID): cv.use_id(NASA_Controller),
         cv.Required(CONF_ID): cv.ensure_list(cv.use_id(NASA_Base))
-    })
+    }),
+    synchronous=False
 )
 async def request_read_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[NASA_CONTROLLER_ID])
@@ -146,7 +147,8 @@ async def request_read_to_code(config, action_id, template_arg, args):
                 cv.Required("value"): cv.templatable(cv.Any(cv.float_, cv.boolean, cv.string_strict)),
             })
         ),
-    })
+    }),
+    synchronous=False
 )
 async def request_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[NASA_CONTROLLER_ID])

--- a/components/samsung_nasa/climate/__init__.py
+++ b/components/samsung_nasa/climate/__init__.py
@@ -96,7 +96,11 @@ CLIMATE_ACTION_SCHEMA = cv.Schema(
     }
 )
 
-@automation.register_action("climate.action", ClimateSetAction, CLIMATE_ACTION_SCHEMA)
+@automation.register_action(
+        "climate.action", 
+        ClimateSetAction, 
+        CLIMATE_ACTION_SCHEMA,
+        synchronous=False)
 async def climate_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)

--- a/components/samsung_nasa/climate/nasa_climate.cpp
+++ b/components/samsung_nasa/climate/nasa_climate.cpp
@@ -21,6 +21,7 @@ void NASA_Climate::setup() {
     this->action_sens_->add_on_state_callback([this](float state) { this->on_action_sens(state); });
   }
   if (this->select_presets_ != nullptr) {
+    this->set_supported_custom_presets(this->select_presets_->traits.get_options());
     this->select_presets_->add_on_state_callback([this](size_t index) {
       auto state = this->select_presets_->traits.get_options()[index];
       this->on_preset_select(state, index);
@@ -216,12 +217,6 @@ climate::ClimateTraits NASA_Climate::traits() {
     }
   }
 
-  traits.set_supported_presets({});
-  if (this->select_presets_ != nullptr) {
-    const auto &options = this->select_presets_->traits.get_options();
-    std::vector<const char *> preset_pointers(options.begin(), options.end());
-    traits.set_supported_custom_presets(preset_pointers);
-  }
   return traits;
 }
 

--- a/example.yaml
+++ b/example.yaml
@@ -6,7 +6,7 @@ external_components:
 esphome:
   name: samsung_nasa
   friendly_name: Heat Pump
-  min_version: 2026.3.0
+  min_version: 2026.4.0
 
 esp32:
   board: m5stack-atom


### PR DESCRIPTION
Handles further changes in the ESPHome Climate API. Please note set_supported_custom_presets requires 2026.4.0 and later. Handles Action synchronisation warnings by adding synchronous=False.