### PR TITLE
Fix for ESPHome 2026.5.0 Polling Component Breaking Change

### DIFF
--- a/components/samsung_nasa/__init__.py
+++ b/components/samsung_nasa/__init__.py
@@ -94,7 +94,7 @@ client_schema = cv.Schema(
         cv.Optional(NASA_MIN_RETRIES, default= 1): cv.int_range(1, 10),
         cv.Optional(NASA_SEND_TIMEOUT, default=4000): cv.int_range(1000, 10000)                    
     }
-)
+).extend(cv.polling_component_schema("10s"))
 
 CONFIG_SCHEMA = cv.Schema(
         {
@@ -182,7 +182,10 @@ async def request_write_to_code(config, action_id, template_arg, args):
 
 async def to_code(config):
     conf_client = config[NASA_CLIENT]
-    client_var = cg.new_Pvariable(conf_client[NASA_CLIENT_ID])
+    # Extract the client's specific interval from its nested schema map
+    client_interval = conf_client["update_interval"]
+    # Pass the interval into the updated C++ class constructor
+    client_var = cg.new_Pvariable(conf_client[NASA_CLIENT_ID], client_interval)
     if (conf_pin:= conf_client.get(CONF_FLOW_CONTROL_PIN)) is not None:
         pin = await gpio_pin_expression(conf_pin)
         cg.add(client_var.set_flow_control_pin(pin))

--- a/components/samsung_nasa/nasa_client.cpp
+++ b/components/samsung_nasa/nasa_client.cpp
@@ -42,8 +42,8 @@ void NASA_Client::loop() {
   // Modernized Loop Execution Path (ESPHome 2026.5+)
   // Run both routines unconditionally every cycle. This prevents read loops 
   // from starving write execution or stalling the PollingComponent timer.
-  this->read_data()
-  this->write_data()
+  this->read_data();
+  this->write_data();
 }
 
 uint16_t NASA_Client::skip_data(int from) {

--- a/components/samsung_nasa/nasa_client.cpp
+++ b/components/samsung_nasa/nasa_client.cpp
@@ -39,10 +39,11 @@ void NASA_Client::loop() {
   this->dispatcher_.update();
   if (data_processing_init)
     return;
-  if (!read_data())
-    return;
-  if (write_data())
-    return;
+  // Modernized Loop Execution Path (ESPHome 2026.5+)
+  // Run both routines unconditionally every cycle. This prevents read loops 
+  // from starving write execution or stalling the PollingComponent timer.
+  this->read_data()
+  this->write_data()
 }
 
 uint16_t NASA_Client::skip_data(int from) {

--- a/components/samsung_nasa/nasa_client.h
+++ b/components/samsung_nasa/nasa_client.h
@@ -32,7 +32,7 @@ class NASA_Client : public PollingComponent, public uart::UARTDevice {
   using RegisterAddressFunc = std::function<void(std::string)>;
   using RegisterReceiveFunc = std::function<bool(std::string, MessageSet &)>;
 
-  NASA_Client() = default;
+  NASA_Client(uint32_t update_interval) : PollingComponent(update_interval) {};
   float get_setup_priority() const override { return setup_priority::DATA; };
   void setup() override;
   void update() override;

--- a/example.yaml
+++ b/example.yaml
@@ -6,7 +6,7 @@ external_components:
 esphome:
   name: samsung_nasa
   friendly_name: Heat Pump
-  min_version: 2026.4.0
+  min_version: 2026.5.0
 
 esp32:
   board: m5stack-atom


### PR DESCRIPTION
NB: This change is not backwards compatible - you must update ESPHome to minimum version 2026.5.0 